### PR TITLE
fix: pin gatsby@2.24.65

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@adobe/gatsby-theme-parliament": "^2.7.0",
-    "gatsby": "^2.23.11",
+    "gatsby": "2.24.65",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },


### PR DESCRIPTION
To fix "pragma and pragmaFrag cannot be set when runtime is automatic." errors

