### PR TITLE
Correct fix is to add yarnPath to .yarnrc.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,12 +87,12 @@ jobs:
         run: corepack enable
 
       - name: Install Yarn v3
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v3
         with:
-          cmd: set version 3.2.2
+          cmd: set version stable
 
       - name: Install Dependencies
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v3
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
         with:
@@ -110,12 +110,12 @@ jobs:
 
       - name: Clean Cache
         if: needs.set-state.outputs.clean_cache == 'true'
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v3
         with:
           cmd: clean
 
       - name: Build site
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v3
         with:
           cmd: build
         env:
@@ -190,12 +190,12 @@ jobs:
         run: corepack enable
 
       - name: Install Yarn v3
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v3
         with:
-          cmd: set version 3.2.2
+          cmd: set version stable
 
       - name: Install Dependencies
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v3
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
         with:
@@ -213,12 +213,12 @@ jobs:
 
       - name: Clean Cache
         if: needs.set-state.outputs.clean_cache == 'true'
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v3
         with:
           cmd: clean
 
       - name: Build site
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v3
         with:
           cmd: build
         env:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,2 @@
 nodeLinker: node-modules
+yarnPath: .yarn/releases/yarn-3.2.2.cjs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

It turns out that yarn 1.22.20+ is enforcing proper config when specifying another packageManager "packageManager": "yarn@3.2.2" and it required the path in the .yarnrc.yml yarnPath: .yarn/releases/yarn-3.2.2.cjs 
The previous version was just ignoring our missing yarnPath.


Remove deploy workaround as no longer necessary.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/yarnpkg/yarn/issues/9015
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
