### PR TITLE
feat: add page for access-check error

### DIFF
--- a/src/pages/erroraccesscheck.md
+++ b/src/pages/erroraccesscheck.md
@@ -1,0 +1,12 @@
+---
+title: We ran into an issue.
+description: Sorry, we ran into an issue checking if you should have access to the requested page.
+---
+
+<Hero slots="heading, text, buttons" variant="fullwidth" theme="lightest"/>
+
+# We ran into an issue.
+
+Sorry, we ran into an issue checking if you should have access to the requested page.
+
+* [Go to homepage](https://developer.adobe.com)

--- a/src/pages/noaccess.md
+++ b/src/pages/noaccess.md
@@ -1,12 +1,12 @@
 ---
 title: No access at this time.
-description: Sorry, you don't have access to this Private Beta page.
+description: Sorry, you don't have access to the requested page.
 ---
 
 <Hero slots="heading, text, buttons" variant="fullwidth" theme="lightest"/>
 
 # No access at this time.
 
-Sorry, you don't have access to this Private Beta page.
+Sorry, you don't have access to the requested page.
 
 * [Go to homepage](https://developer.adobe.com)


### PR DESCRIPTION
### Changes

* Add page to display when an error occurs during a page access check

### Related Issues

* [IOXTD-2290](https://jira.corp.adobe.com/browse/IOXTD-2290)
* Dependency for changes in [developer-website/infrastructure/pull/126](https://git.corp.adobe.com/developer-website/infrastructure/pull/126) (see comments [here](https://git.corp.adobe.com/developer-website/infrastructure/pull/126#discussion_r7143049) and [here](https://git.corp.adobe.com/developer-website/infrastructure/pull/126#discussion_r7143052))